### PR TITLE
Fix code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/src/api/FileUsageStorage.ts
+++ b/src/api/FileUsageStorage.ts
@@ -43,7 +43,11 @@ export class FileUsageStorage implements IUsageStorage {
         // Initialize file path based on tenant information
      
         const ScopeFileName = `${tenant.scopeType}_${tenant.scopeName}_metrics.json`;
-        this.ScopeFilePath = path.join(__dirname, this.dirName, ScopeFileName);
+        const resolvedPath = path.resolve(__dirname, this.dirName, ScopeFileName);
+        if (!resolvedPath.startsWith(path.resolve(__dirname, this.dirName))) {
+            throw new Error('Invalid file path');
+        }
+        this.ScopeFilePath = resolvedPath;
 
         try{
         


### PR DESCRIPTION
Fixes [https://github.com/DevOps-zhuang/copilot-metric-saver/security/code-scanning/3](https://github.com/DevOps-zhuang/copilot-metric-saver/security/code-scanning/3)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root directory. This can be achieved by normalizing the path using `path.resolve` and then checking that the normalized path starts with the root directory. This approach prevents directory traversal attacks by ensuring that any `..` segments are resolved within the root directory.

1. Normalize the constructed file path using `path.resolve`.
2. Check that the normalized path starts with the root directory.
3. If the check fails, handle the error appropriately (e.g., log the error and throw an exception).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
