### PR TITLE
Fix code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/src/api/FileSeatStorage.ts
+++ b/src/api/FileSeatStorage.ts
@@ -30,12 +30,16 @@ export class FileSeatStorage implements ISeatStorage {
     private initializeFilePath(tenant: Tenant) {
         const LatestFileName = `${tenant.scopeType}_${tenant.scopeName}_${this.latestFilePostfix}`;
         const SeatFileName = `${tenant.scopeType}_${tenant.scopeName}_${this.seatFilePostfix}`;
-        this.LatestFilePath = path.join(__dirname, this.dirName, LatestFileName);
-        this.SeatFilePath = path.join(__dirname, this.dirName, SeatFileName);
+        const rootDir = path.resolve(__dirname, this.dirName);
+        this.LatestFilePath = path.resolve(rootDir, LatestFileName);
+        this.SeatFilePath = path.resolve(rootDir, SeatFileName);
 
         try {
-            if (!fs.existsSync(path.join(__dirname, this.dirName))) {
-                fs.mkdirSync(path.join(__dirname, this.dirName));
+            if (!this.LatestFilePath.startsWith(rootDir) || !this.SeatFilePath.startsWith(rootDir)) {
+                throw new Error('File paths are outside the root directory');
+            }
+            if (!fs.existsSync(rootDir)) {
+                fs.mkdirSync(rootDir);
             }
             if (!fs.existsSync(this.LatestFilePath)) {
                 // Create empty file, no content


### PR DESCRIPTION
Fixes [https://github.com/DevOps-zhuang/copilot-metric-saver/security/code-scanning/4](https://github.com/DevOps-zhuang/copilot-metric-saver/security/code-scanning/4)

To fix the problem, we need to ensure that the constructed file paths are contained within a safe root directory. This can be achieved by normalizing the paths using `path.resolve` and then verifying that the normalized paths start with the root directory. 

1. Normalize the constructed file paths using `path.resolve`.
2. Check that the normalized paths start with the root directory.
3. If the paths do not start with the root directory, handle the error appropriately (e.g., log an error, throw an exception, or return an error response).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
